### PR TITLE
Allow multipart body when digest is optional

### DIFF
--- a/lib/plug_body_digest.ex
+++ b/lib/plug_body_digest.ex
@@ -233,6 +233,14 @@ defmodule PlugBodyDigest do
   """
   @spec optional(Plug.Conn.t(), error_reason(), String.t()) :: Plug.Conn.t()
   def optional(conn, :no_digest_header, _want_digest), do: conn
+
+  def optional(conn, reason, want_digest) when reason in [:body_not_read, :multipart] do
+    case get_digest_header(conn) do
+      {:ok, :no_digest_header} -> conn
+      _otherwise -> failure(conn, reason, want_digest)
+    end
+  end
+
   def optional(conn, reason, want_digest), do: failure(conn, reason, want_digest)
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PlugBodyDigest.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,16 @@ defmodule PlugBodyDigest.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
+    mime_version =
+      if Version.match?(System.version(), ">= 1.10.0") do
+        "~> 1.5 or ~> 2.0"
+      else
+        "~> 1.5"
+      end
+
     [
       {:plug, "~> 1.5"},
+      {:mime, mime_version},
       {:ex_doc, "~> 0.21", only: :dev},
       {:credo, "~> 1.1", only: :dev},
       {:jason, "~> 1.0", only: [:dev, :test]}


### PR DESCRIPTION
The built-in `optional` callback now allows requests with unsupported content types (e.g. multipart) to proceed if no Digest header was sent.