### PR TITLE
Require Elixir 1.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,23 +14,23 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.7.4'
-              otp: '21.0.9'
-          - pair:
-              elixir: '1.8.2'
-              otp: '21.3.8.21'
-          - pair:
-              elixir: '1.9.4'
-              otp: '22.3.4.20'
+              elixir: '1.10.4'
+              otp: '22.3.4.26'
           - pair:
               elixir: '1.10.4'
               otp: '23.0.4'
           - pair:
-              elixir: '1.11.3'
-              otp: '23.3.4.3'
+              elixir: '1.11.4'
+              otp: '23.3.4.17'
           - pair:
-              elixir: '1.12.1'
-              otp: '24.0.2'
+              elixir: '1.12.3'
+              otp: '24.0.6'
+          - pair:
+              elixir: '1.13.4'
+              otp: '24.3.4.4'
+          - pair:
+              elixir: '1.14.0'
+              otp: '25.0.4'
             lint: lint
     steps:
       - uses: actions/checkout@v2

--- a/lib/plug_body_digest.ex
+++ b/lib/plug_body_digest.ex
@@ -157,9 +157,7 @@ defmodule PlugBodyDigest do
   end
 
   defp want_digest(algorithms) do
-    algorithms
-    |> Enum.map(&Crypto.algorithm_name/1)
-    |> Enum.join(",")
+    Enum.map_join(algorithms, ",", &Crypto.algorithm_name/1)
   end
 
   defp on_success(nil, conn), do: conn

--- a/lib/plug_body_digest.ex
+++ b/lib/plug_body_digest.ex
@@ -94,7 +94,17 @@ defmodule PlugBodyDigest do
 
   @impl true
   @spec init(Keyword.t()) :: Keyword.t()
-  def init(opts), do: opts
+  def init(opts) do
+    algorithms = Keyword.get(opts, :algorithms, @algorithms)
+
+    case algorithms -- :crypto.supports(:hashs) do
+      [] ->
+        opts
+
+      invalid ->
+        raise "Invalid digest algorithm(s): #{Enum.join(invalid, ", ")}"
+    end
+  end
 
   @impl true
   @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()

--- a/lib/plug_body_digest/conn_test.ex
+++ b/lib/plug_body_digest/conn_test.ex
@@ -26,11 +26,7 @@ defmodule PlugBodyDigest.ConnTest do
   def with_digest(conn, body_or_digests)
 
   def with_digest(conn, digests) when is_map(digests) do
-    digest_header =
-      digests
-      |> Enum.map(fn {alg, value} -> "#{alg}=#{value}" end)
-      |> Enum.join(",")
-
+    digest_header = Enum.map_join(digests, ",", fn {alg, value} -> "#{alg}=#{value}" end)
     put_req_header(conn, "digest", digest_header)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule PlugBodyDigest.MixProject do
     [
       app: :plug_body_digest,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/test/plug_body_digest_test.exs
+++ b/test/plug_body_digest_test.exs
@@ -267,8 +267,7 @@ defmodule PlugBodyDigestTest do
   defp with_digest(conn, digests) when is_map(digests) do
     digest_header =
       digests
-      |> Enum.map(fn {alg, value} -> "#{alg}=#{value}" end)
-      |> Enum.join(",")
+      |> Enum.map_join(",", fn {alg, value} -> "#{alg}=#{value}" end)
 
     put_req_header(conn, "digest", digest_header)
   end

--- a/test/plug_body_digest_test.exs
+++ b/test/plug_body_digest_test.exs
@@ -8,7 +8,7 @@ defmodule PlugBodyDigestTest do
   describe "configuration" do
     test "unsupported algorithm" do
       assert_raise RuntimeError, fn ->
-        PlugBodyDigest.init([algorithms: [:nosuchthing]])
+        PlugBodyDigest.init(algorithms: [:nosuchthing])
       end
     end
   end


### PR DESCRIPTION
Older Elixir versions are having trouble with the latest versions of Plug, Mime, etc.

Also improves error handling, esp. on OTP 15